### PR TITLE
Removed ftp and replaced with https for downloading sequences from pdb

### DIFF
--- a/src/pdbutils.py
+++ b/src/pdbutils.py
@@ -138,7 +138,8 @@ def retrieve_seqfile(seqfile=None):
     seqfile : str
         The path to the downloaded sequence file.
     """
-    sequrl='ftp://ftp.wwpdb.org/pub/pdb/derived_data/pdb_seqres.txt'
+    #sequrl='ftp://ftp.wwpdb.org/pub/pdb/derived_data/pdb_seqres.txt' FAPA CHANGED ADDRESS FEB 2025
+    sequrl='https://files.wwpdb.org/pub/pdb/derived_data/pdb_seqres.txt'
     if seqfile is None:
         seqfile='seqfile.txt'
     download_from_url(sequrl, seqfile)


### PR DESCRIPTION
On November 2024, the ftp protocol was deprecated from the PDB. We replaced it with https and updated the address to retrieve the sequences from the PDB.